### PR TITLE
CSV-eksport til automatisk fletting av grafikk

### DIFF
--- a/class.rapport.php
+++ b/class.rapport.php
@@ -364,6 +364,43 @@ class rapport{
 		return preg_replace('/[^a-z]/i', '', strtolower($name));
 	}
 	
+	/**
+	 * csv_write function
+	 *
+	 * Creates a file for the CSV-export and writes to it.
+	 * Returns a 
+	 * By @asgeirsh, 26.03.2017
+	 *
+	 */
+	public function csv_write($data) {
+		$tmp_folder = '/home/ukmno/public_subdomains/download/rapporter/';
+		if( 'ukm.dev' == UKM_HOSTNAME ) {
+			$tmp_folder = '/tmp/rapporter/';
+		} 
+		$name = 'UKMRapport_'.$this->pl_id.'_'.$this->_sanName().'_'.date('dmYhis').'.csv';
+
+
+		if ( !is_dir($tmp_folder) ) {
+			mkdir($tmp_folder);
+		}
+		$file = fopen($tmp_folder.$name, 'x');
+		if( false == $file) {
+			echo '<h2>Failed to create file for writing.</h2>';
+			return false;
+		}
+		$write_result = fwrite($file, $data);
+		if( false == $write_result ) {
+			echo '<h2>Failed to write to file.</h2>';
+			return false;
+		}
+		fclose($file);
+
+		$link = 'http://download.ukm.no/?folder=rapporter&filename='.urlencode($name);
+		if( 'ukm.dev' == UKM_HOSTNAME ) {
+			echo '<br><h4>File was written to '.$tmp_folder.$name.'</h4>';
+		}
+		return $link;
+	}
 	
 	/********************************************************************************/
 	/*									WORD (public)								*/
@@ -390,7 +427,6 @@ class rapport{
 		$properties->setModified( time() );
 
 		// Definer noen styles
-
 		$PHPWord->addFontStyle('f_p', array('size'=>10));
 		$PHPWord->addParagraphStyle('p_p', array('spaceAfter'=>0, 'spaceBefore'=>0));
 		$PHPWord->addParagraphStyle('p_bold', array('spaceAfter'=>0, 'spaceBefore'=>0));

--- a/gui.rapport.php
+++ b/gui.rapport.php
@@ -111,6 +111,9 @@ else
 	<li id="skrivut"><?= UKMN_ico('print', 40)?><div class="text">Skriv ut</div></li>
 	<li id="word"><?= UKMN_ico('word-mac', 40)?><div class="text">Last ned som Word-dokument</div></li>
 	<li id="excel"><?= UKMN_ico('excel-mac', 40)?><div class="text">Last ned som Excel-dokument</div></li>
+	<?php if( 'program' == $_GET['rapport'] ) { ?>
+		<li id="csv"><?= UKMN_ico('list', 40)?><div class="text">Last ned som CSV-dokument</div></li>
+	<?php } ?> 
 </ul>
 <ul class="contact_actions" style="display:none;">
 	<li id="mail"><?= UKMN_ico('mail', 40)?><div class="text">Send e-post til alle i rapporten</div></li>

--- a/gui.rapport.php
+++ b/gui.rapport.php
@@ -111,9 +111,12 @@ else
 	<li id="skrivut"><?= UKMN_ico('print', 40)?><div class="text">Skriv ut</div></li>
 	<li id="word"><?= UKMN_ico('word-mac', 40)?><div class="text">Last ned som Word-dokument</div></li>
 	<li id="excel"><?= UKMN_ico('excel-mac', 40)?><div class="text">Last ned som Excel-dokument</div></li>
-	<?php if( 'program' == $_GET['rapport'] ) { ?>
-		<li id="csv"><?= UKMN_ico('list', 40)?><div class="text">Last ned som CSV-dokument</div></li>
-	<?php } ?> 
+		<?php if( 'program' == $_GET['rapport'] ) { ?>
+			<div class="col-xs-8">&nbsp;</div>
+			<br /><br /><br /><br />
+			<a href="#" id="csv" class="clickable">Last ned som CSV-dokument</a>
+		<?php } ?> 
+	</li>
 </ul>
 <ul class="contact_actions" style="display:none;">
 	<li id="mail"><?= UKMN_ico('mail', 40)?><div class="text">Send e-post til alle i rapporten</div></li>

--- a/rapport.script.js
+++ b/rapport.script.js
@@ -90,6 +90,32 @@ jQuery(document).ready(function(){
 		});
 	});
 
+	/// CSV-rapport
+	jQuery('.actions > li#csv').click(function() {
+		console.log("Preparing CSV");
+		var data = 	'action=UKMrapport_ajax'
+				 +	'&get='+jQuery('#UKMrapport').attr('data-rapport')
+				 +	'&kat='+jQuery('#UKMrapport').attr('data-kat')
+				 +	'&csv=true'
+				 + 	'&'+jQuery('#UKMrapport').serialize();
+
+		jQuery('#report_container').hide();
+		jQuery('#report_container_word').html('<span class="loading"><img src="http://ico.ukm.no/loading.gif" width="32" /><div>Vennligst vent, gjør klar CSV-rapport for nedlasting...</div></span>');
+		
+		jQuery.post(ajaxurl, data, function(response) {
+			// Print the response.
+			jQuery("#report_container_word").html(response);
+			
+			// Auto-download
+			/*link = jQuery("#downloadLink").attr('href');
+
+			if( link !== undefined && link !== null ) {
+				window.location.href = link;
+			}*/
+		});
+
+	});
+
 
 	jQuery('li.option, .actions > li, .contact_actions > li').addClass('clickable');
 

--- a/rapport.script.js
+++ b/rapport.script.js
@@ -91,7 +91,7 @@ jQuery(document).ready(function(){
 	});
 
 	/// CSV-rapport
-	jQuery('.actions > li#csv').click(function() {
+	jQuery('.actions > a#csv').click(function() {
 		console.log("Preparing CSV");
 		var data = 	'action=UKMrapport_ajax'
 				 +	'&get='+jQuery('#UKMrapport').attr('data-rapport')

--- a/rapporter.ajax.php
+++ b/rapporter.ajax.php
@@ -18,6 +18,8 @@ function UKMrapport_ajax(){
 		$log = 'word';
 	elseif(isset($_POST['excel']))
 		$log = 'excel';
+	elseif(isset($_POST['csv']))
+		$log = 'csv';
 	else
 		$log = 'skjerm';
 	
@@ -47,6 +49,22 @@ function UKMrapport_ajax(){
 			die('<h2>Beklager!</h2>'
 				.'Rapporten finnes ikke i excel-format');
 	
+		die('<h2>Rapport klar!</h2>'
+			.'Du skal nå få opp spørsmål om å laste ned rapporten. '
+			.'Hvis dette ikke skjer i løpet av de neste 5 sekundene kan du høyreklikke og velge &quot;lagre mål som&quot; '
+			.'<a href="'.$link.'" id="downloadLink">her</a>');
+	}
+
+	if(isset($_POST['csv'])) {
+		$link = $r->generateCSV();
+
+		if( 'ukm.dev' == UKM_HOSTNAME ) {
+			die(); // generateCSV() skriver hvor filen er lagret i dev-modus.
+		}
+		if( !$link ) {
+			die('<h2>Beklager!</h2>'
+				.'Klarte ikke å generere rapporten til deg.');
+		}
 		die('<h2>Rapport klar!</h2>'
 			.'Du skal nå få opp spørsmål om å laste ned rapporten. '
 			.'Hvis dette ikke skjer i løpet av de neste 5 sekundene kan du høyreklikke og velge &quot;lagre mål som&quot; '


### PR DESCRIPTION
Fordi Excel på norsk genererer CSV med semikolon som skillemerke og ikke komma, og ikke takler æ/ø/å godt nok, foreslår jeg en egen CSV-eksport i program-rapport-modulen. Dette vil øke tempoet for å kunne hente ut og flette inn data i grafikk-pakker.

Denne er tunet ekstra til "Datasett"-funksjonaliteten til Photoshop / InDesign / Adobe-pakka pdd, og henter kun ut info som trengs til lower thirds / Super (Innslag, kommune og tittel).

Har observert én bug under testinga - CSV-knappen kommer ~20px for langt til høyre. 
![skjermbilde 2017-03-26 kl 05 40 33](https://cloud.githubusercontent.com/assets/1831028/24328403/225045fa-11e9-11e7-9072-6257f72f1e97.png)
