### PR TITLE
Statisk path for js og css

### DIFF
--- a/ukmrapporter.php
+++ b/ukmrapporter.php
@@ -119,10 +119,10 @@ class UKMrapporter extends Modul
         wp_enqueue_style('WPbootstrap3_css');
         wp_enqueue_script('TwigJS');
 
-        wp_enqueue_style('UKMrapporter_css', self::getPluginUrl() . 'ukmrapporter.css');
-        wp_enqueue_script('UKMrapporter_js', self::getPluginUrl() . 'ukmrapporter.js');
+        wp_enqueue_style('UKMrapporter_css', static::getPluginUrl() . 'ukmrapporter.css');
+        wp_enqueue_script('UKMrapporter_js', static::getPluginUrl() . 'ukmrapporter.js');
 
-        wp_enqueue_style('jquery-ui-style', self::getPluginUrl() . 'UKMNorge/js/css/jquery-ui-1.7.3.custom.css');
+        wp_enqueue_style('jquery-ui-style', static::getPluginUrl() . 'UKMNorge/js/css/jquery-ui-1.7.3.custom.css');
         wp_enqueue_script('GOOGLEchart', 'https://www.google.com/jsapi');
 
         wp_enqueue_script('jquery');

--- a/ukmrapporter.php
+++ b/ukmrapporter.php
@@ -119,10 +119,10 @@ class UKMrapporter extends Modul
         wp_enqueue_style('WPbootstrap3_css');
         wp_enqueue_script('TwigJS');
 
-        wp_enqueue_style('UKMrapporter_css', self::getPluginUrl() . 'ukmrapporter.css');
-        wp_enqueue_script('UKMrapporter_js', self::getPluginUrl() . 'ukmrapporter.js');
+        wp_enqueue_style('UKMrapporter_css', PLUGIN_PATH . 'UKMrapporter/ukmrapporter.css');
+        wp_enqueue_script('UKMrapporter_js', PLUGIN_PATH . 'UKMrapporter/ukmrapporter.js');
 
-        wp_enqueue_style('jquery-ui-style', self::getPluginUrl() . 'UKMNorge/js/css/jquery-ui-1.7.3.custom.css');
+        wp_enqueue_style('jquery-ui-style', PLUGIN_PATH . 'UKMrapporter/UKMNorge/js/css/jquery-ui-1.7.3.custom.css');
         wp_enqueue_script('GOOGLEchart', 'https://www.google.com/jsapi');
 
         wp_enqueue_script('jquery');

--- a/ukmrapporter.php
+++ b/ukmrapporter.php
@@ -119,10 +119,10 @@ class UKMrapporter extends Modul
         wp_enqueue_style('WPbootstrap3_css');
         wp_enqueue_script('TwigJS');
 
-        wp_enqueue_style('UKMrapporter_css', PLUGIN_PATH . 'UKMrapporter/ukmrapporter.css');
-        wp_enqueue_script('UKMrapporter_js', PLUGIN_PATH . 'UKMrapporter/ukmrapporter.js');
+        wp_enqueue_style('UKMrapporter_css', self::getPluginUrl() . 'ukmrapporter.css');
+        wp_enqueue_script('UKMrapporter_js', self::getPluginUrl() . 'ukmrapporter.js');
 
-        wp_enqueue_style('jquery-ui-style', PLUGIN_PATH . 'UKMrapporter/UKMNorge/js/css/jquery-ui-1.7.3.custom.css');
+        wp_enqueue_style('jquery-ui-style', self::getPluginUrl() . 'UKMNorge/js/css/jquery-ui-1.7.3.custom.css');
         wp_enqueue_script('GOOGLEchart', 'https://www.google.com/jsapi');
 
         wp_enqueue_script('jquery');

--- a/ukmrapporter.php
+++ b/ukmrapporter.php
@@ -122,7 +122,7 @@ class UKMrapporter extends Modul
         wp_enqueue_style('UKMrapporter_css', static::getPluginUrl() . 'ukmrapporter.css');
         wp_enqueue_script('UKMrapporter_js', static::getPluginUrl() . 'ukmrapporter.js');
 
-        wp_enqueue_style('jquery-ui-style', static::getPluginUrl() . 'UKMNorge/js/css/jquery-ui-1.7.3.custom.css');
+        wp_enqueue_style('jquery-ui-style');
         wp_enqueue_script('GOOGLEchart', 'https://www.google.com/jsapi');
 
         wp_enqueue_script('jquery');


### PR DESCRIPTION
Bruker en final variable for å definere statisk path-en for å peke på resurser.

Deriverer fra: https://github.com/UKMNorge/UKMresources/issues/3

OBS: UKMconfig.inc.php er modifisert. Denne linjen er lagt til:
"# RESOURCES PLUGIN PATH
define('PLUGIN_PATH', 'https://' . UKM_HOSTNAME . '/wp-content/plugins/');"